### PR TITLE
Check if m3u8 contains audio stream before use

### DIFF
--- a/fansly_downloader.py
+++ b/fansly_downloader.py
@@ -638,12 +638,15 @@ def download_m3u8(m3u8_url: str, save_path: str):
     
     input_container = av.open(io.BytesIO(segment), format='mpegts')
     video_stream = input_container.streams.video[0]
-    audio_stream = input_container.streams.audio[0]
+    audio_stream = False
+    if input_container.streams.audio:
+        audio_stream = input_container.streams.audio[0]
 
     # define output container and streams
     output_container = av.open(f"{save_path}.mp4", 'w') # add .mp4 file extension
     video_stream = output_container.add_stream(template=video_stream)
-    audio_stream = output_container.add_stream(template=audio_stream)
+    if audio_stream:
+        audio_stream = output_container.add_stream(template=audio_stream)
 
     start_pts = None
     for packet in input_container.demux():
@@ -658,7 +661,7 @@ def download_m3u8(m3u8_url: str, save_path: str):
 
         if packet.stream == input_container.streams.video[0]:
             packet.stream = video_stream
-        elif packet.stream == input_container.streams.audio[0]:
+        elif audio_stream and packet.stream == input_container.streams.audio[0]:
             packet.stream = audio_stream
         output_container.mux(packet)
 


### PR DESCRIPTION
Hi fellows.

When using I had issues with some m3u8 videos without audio, failing to download the video and crashing the script.

I just added a quick check if there is an audio stream before accessing it.

I hope it help anybody with the same issue :+1: 